### PR TITLE
Update README commands and enhance logger functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ radiko_recorder_rust --station-list
 指定した放送局からラジオ放送を録音するには、以下の形式でコマンドを実行します。
 
 ```sh
-radiko_recorder_rust <station_id> <start_time> <duration_minutes>
+radiko_recorder <station_id> <start_time> <duration_minutes>
 ```
 
 - `<station_id>`: 録音対象の放送局の ID (例: `TBS`, `QRR` など)  
@@ -54,7 +54,7 @@ radiko_recorder_rust <station_id> <start_time> <duration_minutes>
 
 **例:**
 ```sh
-radiko_recorder_rust FMT 20241120120000 50
+radiko_recorder FMT 20241120120000 50
 ```
 
 上記の例では、2024年11月20日12:00:00 から 50 分間、TOKYO FM の放送を録音します。
@@ -71,7 +71,7 @@ cd radiko_recorder_rust
 cargo build --release
 ```
 
-ビルドが完了すると、実行ファイルは `target/release/radiko_recorder_rust` に生成されます。
+ビルドが完了すると、実行ファイルは `target/release` に生成されます。
 
 ## ログ出力
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -25,10 +25,19 @@ pub fn setup_logger() -> Result<(), Box<dyn std::error::Error>> {
         .warn(Color::Yellow)
         .error(Color::Red);
     
+    // ビルドモードに応じてログレベルを切り替え
+    let log_level = if cfg!(debug_assertions) {
+        // デバッグビルドのときは詳細なログを出力
+        log::LevelFilter::Debug
+    } else {
+        // リリースビルドのときは Info 以上のみ出力
+        log::LevelFilter::Info
+    };
+
     // fern の Dispatch を使ってロガーを設定
     Dispatch::new()
         // ログレベルを Debug 以上に設定
-        .level(log::LevelFilter::Info)
+        .level(log_level)
         // ファイル出力（非カラー、フォーマット: "YYYY-MM-DD HH:MM:SS LEVEL   target message"）
         .chain(
             Dispatch::new()


### PR DESCRIPTION
Update command examples in README.md to reflect the new executable name and add functionality to switch the logger's log level based on the build mode.