### PR TITLE
Change executable name and update README command examples; improve logger settings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
             "type": "lldb",
             "request": "launch",
             "name": "Rust Debug Launch",
-            "program": "${workspaceRoot}/target/debug/${workspaceRootFolderName}",
+            "program": "${workspaceRoot}/target/debug/radiko_recorder.exe",
             "args": [
                 "-a", "JP13", "FMT", "20250210120000", "30"
             ],

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Rust の高速性と安全性を活かして実装されており、シンプル
 放送局リストを表示するには、`--station-list` オプションを利用します。
 
 ```sh
-radiko_recorder_rust --station-list
+radiko_recorder --station-list
 ```
 
 ### 放送局の録音


### PR DESCRIPTION
Change the executable name to `radiko_recorder` and update the corresponding command examples in the README. Enhance logger configuration for better clarity and output management.